### PR TITLE
add case to skip empty filenames while 'walking' in s3 store

### DIFF
--- a/s3store.go
+++ b/s3store.go
@@ -294,7 +294,12 @@ func (s *S3Store) Walk(ctx context.Context, prefix, _ string, f func(filename st
 	var innerErr error
 	err := s.service.ListObjectsV2PagesWithContext(ctx, q, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
 		for _, el := range page.Contents {
-			if err := f(s.toBaseName(*el.Key)); err != nil {
+			filename := s.toBaseName(*el.Key)
+			if filename == "" {
+				zlog.Warn("got an empty filename from s3 store, ignoring it", zap.String("key", *el.Key))
+				continue
+			}
+			if err := f(filename); err != nil {
 				if err == StopIteration {
 					return false
 				}


### PR DESCRIPTION
Dan saw that behavior on Amazon S3, it broke with a panic in consuming code