### PR TITLE
replace metering with callback functionality.

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -1,0 +1,59 @@
+package dstore
+
+import (
+	"context"
+	"io"
+)
+
+type callbackWriter struct {
+	w   io.Writer
+	ctx context.Context
+
+	callback func(ctx context.Context, n int)
+}
+
+func (cbw *callbackWriter) Write(p []byte) (n int, err error) {
+	n, err = cbw.w.Write(p)
+
+	if cbw.callback != nil {
+		cbw.callback(cbw.ctx, n)
+	}
+
+	return
+}
+
+type callbackReadCloser struct {
+	rc  io.ReadCloser
+	ctx context.Context
+
+	callback func(ctx context.Context, n int)
+}
+
+func (cbr *callbackReadCloser) Read(p []byte) (n int, err error) {
+	n, err = cbr.rc.Read(p)
+
+	if cbr.callback != nil {
+		cbr.callback(cbr.ctx, n)
+	}
+	return
+}
+
+func (cbr *callbackReadCloser) Close() error {
+	return cbr.rc.Close()
+}
+
+type callbackReader struct {
+	r   io.Reader
+	ctx context.Context
+
+	callback func(ctx context.Context, n int)
+}
+
+func (cbr *callbackReader) Read(p []byte) (n int, err error) {
+	n, err = cbr.r.Read(p)
+
+	if cbr.callback != nil {
+		cbr.callback(cbr.ctx, n)
+	}
+	return
+}

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,356 @@
+package dstore
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleCompressedWriteCallback(t *testing.T) {
+	compressedWriteBytes := 0
+
+	c := commonStore{
+		compressionType: "gzip",
+		compressedWriteCallback: func(ctx context.Context, n int) {
+			compressedWriteBytes += n
+		},
+	}
+
+	fullsize := 1024
+
+	f := io.Reader(bytes.NewBuffer(bytes.Repeat([]byte("1"), fullsize)))
+	w := bytes.NewBuffer(nil)
+
+	err := c.compressedCopy(context.Background(), w, f)
+	require.NoError(t, err)
+
+	assert.Greater(t, compressedWriteBytes, 0)
+	assert.Less(t, compressedWriteBytes, fullsize)
+}
+
+func TestSimpleUncompressedWriteCallback(t *testing.T) {
+	uncompressedWriteBytes := 0
+
+	c := commonStore{
+		compressionType: "gzip",
+		uncompressedWriteCallback: func(ctx context.Context, n int) {
+			uncompressedWriteBytes += n
+		},
+	}
+
+	fullsize := 1024
+
+	f := io.Reader(bytes.NewBuffer(bytes.Repeat([]byte("1"), fullsize)))
+	w := bytes.NewBuffer(nil)
+
+	err := c.compressedCopy(context.Background(), w, f)
+	require.NoError(t, err)
+
+	assert.Greater(t, uncompressedWriteBytes, 0)
+	assert.Equal(t, uncompressedWriteBytes, fullsize)
+}
+
+func TestSimpleCompressedReadCallback(t *testing.T) {
+	compressedReadBytes := 0
+
+	c := commonStore{
+		compressionType: "gzip",
+		compressedReadCallback: func(ctx context.Context, n int) {
+			compressedReadBytes += n
+		},
+	}
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(bytes.Repeat([]byte("1"), 1024))
+	require.NoError(t, err)
+
+	err = zw.Close()
+	require.NoError(t, err)
+
+	f := io.NopCloser(&buf)
+
+	r, err := c.uncompressedReader(context.Background(), f)
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Greater(t, compressedReadBytes, 0)
+	assert.Less(t, compressedReadBytes, 1024)
+}
+
+func TestSimpleUncompressedReadCallback(t *testing.T) {
+	uncompressedReadBytes := 0
+
+	c := commonStore{
+		compressionType: "gzip",
+		uncompressedReadCallback: func(ctx context.Context, n int) {
+			uncompressedReadBytes += n
+		},
+	}
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(bytes.Repeat([]byte("1"), 1024))
+	require.NoError(t, err)
+
+	err = zw.Close()
+	require.NoError(t, err)
+
+	f := io.NopCloser(&buf)
+
+	r, err := c.uncompressedReader(context.Background(), f)
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Greater(t, uncompressedReadBytes, 0)
+	assert.Equal(t, uncompressedReadBytes, 1024)
+}
+
+func TestCompressedCopyGzip(t *testing.T) {
+	uncompressedN := 0
+	compressedN := 0
+
+	readBytes := 0
+
+	c := commonStore{
+		compressionType: "gzip",
+		uncompressedWriteCallback: func(ctx context.Context, n int) {
+			uncompressedN += n
+		},
+		compressedWriteCallback: func(ctx context.Context, n int) {
+			compressedN += n
+		},
+	}
+
+	f := io.Reader(bytes.NewBuffer(bytes.Repeat([]byte("1"), 1024)))
+	f = &callbackReader{
+		r:   f,
+		ctx: context.Background(),
+		callback: func(ctx context.Context, n int) {
+			readBytes += n
+		},
+	}
+	w := bytes.NewBuffer(nil)
+
+	err := c.compressedCopy(context.Background(), w, f)
+	require.NoError(t, err)
+
+	assert.Greater(t, readBytes, 0)
+	assert.Equal(t, readBytes, uncompressedN)
+
+	assert.Greater(t, uncompressedN, 0)
+	assert.Greater(t, compressedN, 0)
+	assert.Greater(t, uncompressedN, compressedN)
+}
+
+func TestCompressedCopyZstd(t *testing.T) {
+	uncompressedN := 0
+	compressedN := 0
+
+	readBytes := 0
+
+	c := commonStore{
+		compressionType: "zstd",
+		uncompressedWriteCallback: func(ctx context.Context, n int) {
+			uncompressedN += n
+		},
+		compressedWriteCallback: func(ctx context.Context, n int) {
+			compressedN += n
+		},
+	}
+
+	f := io.Reader(bytes.NewBuffer(bytes.Repeat([]byte("1"), 1024)))
+	f = &callbackReader{
+		r:   f,
+		ctx: context.Background(),
+		callback: func(ctx context.Context, n int) {
+			readBytes += n
+		},
+	}
+	w := bytes.NewBuffer(nil)
+
+	err := c.compressedCopy(context.Background(), w, f)
+	require.NoError(t, err)
+
+	assert.Greater(t, readBytes, 0)
+	assert.Equal(t, readBytes, uncompressedN)
+
+	assert.Greater(t, uncompressedN, 0)
+	assert.Greater(t, compressedN, 0)
+	assert.Greater(t, uncompressedN, compressedN)
+}
+
+func TestCompressedCopyPlain(t *testing.T) {
+	uncompressedN := 0
+	compressedN := 0
+
+	readBytes := 0
+
+	c := commonStore{
+		uncompressedWriteCallback: func(ctx context.Context, n int) {
+			uncompressedN += n
+		},
+		compressedWriteCallback: func(ctx context.Context, n int) {
+			compressedN += n
+		},
+	}
+
+	f := io.Reader(bytes.NewBuffer(bytes.Repeat([]byte("1"), 1024)))
+	f = &callbackReader{
+		r:   f,
+		ctx: context.Background(),
+		callback: func(ctx context.Context, n int) {
+			readBytes += n
+		},
+	}
+	w := bytes.NewBuffer(nil)
+
+	err := c.compressedCopy(context.Background(), w, f)
+	require.NoError(t, err)
+
+	assert.Greater(t, readBytes, 0)
+	assert.Equal(t, readBytes, uncompressedN)
+
+	assert.Greater(t, uncompressedN, 0)
+	assert.Greater(t, compressedN, 0)
+	assert.Equal(t, uncompressedN, compressedN)
+}
+
+func TestUncompressedReaderGzip(t *testing.T) {
+	uncompressedN := 0
+	compressedN := 0
+
+	readBytes := 0
+
+	c := commonStore{
+		compressionType: "gzip",
+		uncompressedReadCallback: func(ctx context.Context, n int) {
+			uncompressedN += n
+		},
+		compressedReadCallback: func(ctx context.Context, n int) {
+			compressedN += n
+		},
+	}
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(bytes.Repeat([]byte("1"), 1024))
+	require.NoError(t, err)
+
+	err = zw.Close()
+	require.NoError(t, err)
+
+	f := &callbackReadCloser{
+		rc:  io.NopCloser(&buf),
+		ctx: context.Background(),
+		callback: func(ctx context.Context, n int) {
+			readBytes += n
+		},
+	}
+
+	ur, err := c.uncompressedReader(context.Background(), f)
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(ur)
+	require.NoError(t, err)
+
+	require.Greater(t, readBytes, 0)
+	assert.Equal(t, readBytes, compressedN)
+
+	assert.Greater(t, uncompressedN, 0)
+	assert.Greater(t, compressedN, 0)
+	assert.Greater(t, uncompressedN, compressedN)
+}
+
+func TestUncompressedReaderZstd(t *testing.T) {
+	uncompressedN := 0
+	compressedN := 0
+
+	readBytes := 0
+
+	c := commonStore{
+		compressionType: "zstd",
+		uncompressedReadCallback: func(ctx context.Context, n int) {
+			uncompressedN += n
+		},
+		compressedReadCallback: func(ctx context.Context, n int) {
+			compressedN += n
+		},
+	}
+
+	var buf bytes.Buffer
+	zw, _ := zstd.NewWriter(&buf)
+	_, err := zw.Write(bytes.Repeat([]byte("1"), 1024))
+	require.NoError(t, err)
+
+	err = zw.Close()
+	require.NoError(t, err)
+
+	f := &callbackReadCloser{
+		rc:  io.NopCloser(&buf),
+		ctx: context.Background(),
+		callback: func(ctx context.Context, n int) {
+			readBytes += n
+		},
+	}
+
+	ur, err := c.uncompressedReader(context.Background(), f)
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(ur)
+	require.NoError(t, err)
+
+	require.Greater(t, readBytes, 0)
+	assert.Equal(t, readBytes, compressedN)
+
+	assert.Greater(t, uncompressedN, 0)
+	assert.Greater(t, compressedN, 0)
+	assert.Greater(t, uncompressedN, compressedN)
+}
+
+func TestUncompressedReaderPlain(t *testing.T) {
+	uncompressedN := 0
+	compressedN := 0
+
+	writtenBytes := 0
+
+	c := commonStore{
+		uncompressedReadCallback: func(ctx context.Context, n int) {
+			uncompressedN += n
+		},
+		compressedReadCallback: func(ctx context.Context, n int) {
+			compressedN += n
+		},
+	}
+
+	f := &callbackReadCloser{
+		rc:  io.NopCloser(bytes.NewBuffer(bytes.Repeat([]byte("1"), 1024))),
+		ctx: context.Background(),
+		callback: func(ctx context.Context, n int) {
+			writtenBytes += n
+		},
+	}
+
+	ur, err := c.uncompressedReader(context.Background(), f)
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(ur)
+	require.NoError(t, err)
+
+	assert.Greater(t, writtenBytes, 0)
+	assert.Equal(t, writtenBytes, uncompressedN)
+
+	assert.Greater(t, uncompressedN, 0)
+	assert.Greater(t, compressedN, 0)
+	assert.Equal(t, uncompressedN, compressedN)
+}

--- a/context.go
+++ b/context.go
@@ -8,16 +8,33 @@ import (
 	"go.uber.org/zap"
 )
 
+type fileKey string
+type storeKey string
+
 func withLogger(ctx context.Context, logger *zap.Logger, tracer logging.Tracer) context.Context {
 	ctx = context.WithValue(ctx, "logger", logger)
 	ctx = context.WithValue(ctx, "tracer", tracer)
 	return ctx
 }
 
-func withStore(ctx context.Context, storeType string) context.Context {
-	return context.WithValue(ctx, "store", storeType)
+func withStoreType(ctx context.Context, storeType string) context.Context {
+	return context.WithValue(ctx, storeKey("store"), storeType)
 }
 
-func withFile(ctx context.Context, filename string) context.Context {
-	return context.WithValue(ctx, "file", filename)
+func StoreTypeFromContext(ctx context.Context) string {
+	if v := ctx.Value(storeKey("store")); v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
+func withFileName(ctx context.Context, filename string) context.Context {
+	return context.WithValue(ctx, fileKey("file"), filename)
+}
+
+func FileNameFromContext(ctx context.Context) string {
+	if v := ctx.Value(fileKey("file")); v != nil {
+		return v.(string)
+	}
+	return ""
 }

--- a/stores_test.go
+++ b/stores_test.go
@@ -1,0 +1,77 @@
+package dstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithUncompressedReadCallback(t *testing.T) {
+	conf := &config{}
+
+	opt := WithUncompressedReadCallback(func(ctx context.Context, n int) {})
+	opt.apply(conf)
+
+	assert.NotNil(t, conf.uncompressedReadCallback)
+	assert.Nil(t, conf.compressedReadCallback)
+	assert.Nil(t, conf.compressedWriteCallback)
+	assert.Nil(t, conf.uncompressedWriteCallback)
+}
+
+func TestWithCompressedReadCallback(t *testing.T) {
+	conf := &config{}
+
+	opt := WithCompressedReadCallback(func(ctx context.Context, n int) {})
+	opt.apply(conf)
+
+	assert.Nil(t, conf.uncompressedReadCallback)
+	assert.NotNil(t, conf.compressedReadCallback)
+	assert.Nil(t, conf.compressedWriteCallback)
+	assert.Nil(t, conf.uncompressedWriteCallback)
+}
+
+func TestWithCompressedWriteCallback(t *testing.T) {
+	conf := &config{}
+
+	opt := WithCompressedWriteCallback(func(ctx context.Context, n int) {})
+	opt.apply(conf)
+
+	assert.Nil(t, conf.uncompressedReadCallback)
+	assert.Nil(t, conf.compressedReadCallback)
+	assert.NotNil(t, conf.compressedWriteCallback)
+	assert.Nil(t, conf.uncompressedWriteCallback)
+}
+
+func TestWithUncompressedWriteCallback(t *testing.T) {
+	conf := &config{}
+
+	opt := WithUncompressedWriteCallback(func(ctx context.Context, n int) {})
+	opt.apply(conf)
+
+	assert.Nil(t, conf.uncompressedReadCallback)
+	assert.Nil(t, conf.compressedReadCallback)
+	assert.Nil(t, conf.compressedWriteCallback)
+	assert.NotNil(t, conf.uncompressedWriteCallback)
+}
+
+func TestWithAllCallbacks(t *testing.T) {
+	conf := &config{}
+
+	opt := WithCompressedWriteCallback(func(ctx context.Context, n int) {})
+	opt.apply(conf)
+
+	opt = WithCompressedReadCallback(func(ctx context.Context, n int) {})
+	opt.apply(conf)
+
+	opt = WithUncompressedWriteCallback(func(ctx context.Context, n int) {})
+	opt.apply(conf)
+
+	opt = WithUncompressedReadCallback(func(ctx context.Context, n int) {})
+	opt.apply(conf)
+
+	assert.NotNil(t, conf.uncompressedReadCallback)
+	assert.NotNil(t, conf.compressedReadCallback)
+	assert.NotNil(t, conf.compressedWriteCallback)
+	assert.NotNil(t, conf.uncompressedWriteCallback)
+}

--- a/storetests/gs/gsstore_test.go
+++ b/storetests/gs/gsstore_test.go
@@ -23,7 +23,7 @@ var zlog, tracer = logging.PackageLogger("dstore", "github.com/streamingfast/dst
 
 // For dfusers, one can use:
 //
-//	STORETESTS_GS_STORE_URL="gs://dfuse-developement-random/store-tests"
+//	STORETESTS_GS_STORE_URL=gs://dfuse-developement-random/store-tests
 var gsStoreBaseURL = os.Getenv("STORETESTS_GS_STORE_URL")
 
 func TestGSStore(t *testing.T) {
@@ -44,7 +44,55 @@ func TestGSStore_Overwrite(t *testing.T) {
 	storetests.TestAll(t, createGSStoreFactory(t, gsStoreBaseURL, "", true))
 }
 
-func createGSStoreFactory(t *testing.T, directory string, compression string, overwrite bool) storetests.StoreFactory {
+func TestGSStore_CompressionAndMetering(t *testing.T) {
+	compressedReadByteCount := 0
+	compressedWriteByteCount := 0
+	uncompressedReadByteCount := 0
+	uncompressedWriteByteCount := 0
+
+	var uncompressedRead string
+	var compressedRead string
+	var compressedWrite string
+	var uncompressedWrite string
+
+	opts := []dstore.Option{
+		dstore.WithCompressedReadCallback(func(ctx context.Context, i int) {
+			compressedReadByteCount += i
+			compressedRead = "compressedRead"
+		}),
+		dstore.WithUncompressedReadCallback(func(ctx context.Context, i int) {
+			uncompressedReadByteCount += i
+			uncompressedRead = "uncompressedRead"
+		}),
+		dstore.WithCompressedWriteCallback(func(ctx context.Context, i int) {
+			compressedWriteByteCount += i
+			compressedWrite = "compressedWrite"
+		}),
+		dstore.WithUncompressedWriteCallback(func(ctx context.Context, i int) {
+			uncompressedWriteByteCount += i
+			uncompressedWrite = "uncompressedWrite"
+		}),
+	}
+
+	if gsStoreBaseURL == "" {
+		t.Skip("You must provide a valid Google Storage Bucket via STORETESTS_GS_STORE_URL environment variable to execute those tests")
+		return
+	}
+
+	storetests.TestAll(t, createGSStoreFactory(t, gsStoreBaseURL, "zstd", false, opts...))
+
+	require.Equal(t, "compressedRead", compressedRead)
+	require.Equal(t, "uncompressedRead", uncompressedRead)
+	require.Equal(t, "compressedWrite", compressedWrite)
+	require.Equal(t, "uncompressedWrite", uncompressedWrite)
+
+	require.True(t, compressedReadByteCount > 0, "compressed read byte count should be greater than 0")
+	require.True(t, compressedWriteByteCount > 0, "compressed write byte count should be greater than 0")
+	require.True(t, uncompressedReadByteCount > 0, "uncompressed read byte count should be greater than 0")
+	require.True(t, uncompressedWriteByteCount > 0, "uncompressed write byte count should be greater than 0")
+}
+
+func createGSStoreFactory(t *testing.T, directory string, compression string, overwrite bool, opts ...dstore.Option) storetests.StoreFactory {
 	random := rand.NewSource(time.Now().UnixNano())
 
 	return func() (dstore.Store, storetests.StoreDescriptor, storetests.StoreCleanup) {
@@ -58,7 +106,7 @@ func createGSStoreFactory(t *testing.T, directory string, compression string, ov
 		require.NoError(t, err)
 
 		zlog.Debug("creating a new gsstore for test", zap.Stringer("url", storeURL), zap.String("host", storeURL.Host), zap.String("path", storeURL.Path))
-		store, err := dstore.NewGSStore(storeURL, "", compression, overwrite)
+		store, err := dstore.NewGSStore(storeURL, "", compression, overwrite, opts...)
 		require.NoError(t, err)
 
 		client, err := storage.NewClient(context.Background())

--- a/storetests/local/localstore_test.go
+++ b/storetests/local/localstore_test.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -25,7 +26,50 @@ func TestLocalStoreCompressedZst(t *testing.T) {
 	storetests.TestAll(t, createlocalStoreFactory(t, "zstd"))
 }
 
-func createlocalStoreFactory(t *testing.T, compression string) storetests.StoreFactory {
+func TestLocalStore_CompressionAndMetering(t *testing.T) {
+	compressedReadByteCount := 0
+	compressedWriteByteCount := 0
+	uncompressedReadByteCount := 0
+	uncompressedWriteByteCount := 0
+
+	var uncompressedRead string
+	var compressedRead string
+	var compressedWrite string
+	var uncompressedWrite string
+
+	opts := []dstore.Option{
+		dstore.WithCompressedReadCallback(func(ctx context.Context, i int) {
+			compressedReadByteCount += i
+			compressedRead = "compressedRead"
+		}),
+		dstore.WithUncompressedReadCallback(func(ctx context.Context, i int) {
+			uncompressedReadByteCount += i
+			uncompressedRead = "uncompressedRead"
+		}),
+		dstore.WithCompressedWriteCallback(func(ctx context.Context, i int) {
+			compressedWriteByteCount += i
+			compressedWrite = "compressedWrite"
+		}),
+		dstore.WithUncompressedWriteCallback(func(ctx context.Context, i int) {
+			uncompressedWriteByteCount += i
+			uncompressedWrite = "uncompressedWrite"
+		}),
+	}
+
+	storetests.TestAll(t, createlocalStoreFactory(t, "zstd", opts...))
+
+	require.Equal(t, "compressedRead", compressedRead)
+	require.Equal(t, "uncompressedRead", uncompressedRead)
+	require.Equal(t, "compressedWrite", compressedWrite)
+	require.Equal(t, "uncompressedWrite", uncompressedWrite)
+
+	require.True(t, compressedReadByteCount > 0, "compressed read byte count should be greater than 0")
+	require.True(t, compressedWriteByteCount > 0, "compressed write byte count should be greater than 0")
+	require.True(t, uncompressedReadByteCount > 0, "uncompressed read byte count should be greater than 0")
+	require.True(t, uncompressedWriteByteCount > 0, "uncompressed write byte count should be greater than 0")
+}
+
+func createlocalStoreFactory(t *testing.T, compression string, opts ...dstore.Option) storetests.StoreFactory {
 	random := rand.NewSource(time.Now().UnixNano())
 
 	return func() (dstore.Store, storetests.StoreDescriptor, storetests.StoreCleanup) {
@@ -46,7 +90,7 @@ func createlocalStoreFactory(t *testing.T, compression string) storetests.StoreF
 			os.RemoveAll(dir)
 		}
 
-		store, err := dstore.NewLocalStore(&url.URL{Scheme: "file", Path: dir}, "", compression, false)
+		store, err := dstore.NewLocalStore(&url.URL{Scheme: "file", Path: dir}, "", compression, false, opts...)
 		require.NoError(t, err)
 
 		return store, storetests.StoreDescriptor{

--- a/storetests/open_object_tests.go
+++ b/storetests/open_object_tests.go
@@ -9,6 +9,7 @@ import (
 
 var openObjectTests = []StoreTestFunc{
 	TestOpenObject_ReadSameFileMultipleTimes,
+	TestOpenObject_ReadFileOnce,
 }
 
 func TestOpenObject_ErrNotFound(t *testing.T, factory StoreFactory) {
@@ -18,6 +19,17 @@ func TestOpenObject_ErrNotFound(t *testing.T, factory StoreFactory) {
 	rd, err := store.OpenObject(ctx, "anything_that_does_not_exist")
 	assert.Nil(t, rd)
 	assert.Equal(t, dstore.ErrNotFound, err)
+}
+
+func TestOpenObject_ReadFileOnce(t *testing.T, factory StoreFactory) {
+	store, _, cleanup := factory()
+	defer cleanup()
+
+	addFileToStore(t, store, "file", "c1")
+
+	rd, err := store.OpenObject(ctx, "file")
+	assert.NoError(t, err)
+	assert.Equal(t, "c1", readObjectAndClose(t, rd))
 }
 
 func TestOpenObject_ReadSameFileMultipleTimes(t *testing.T, factory StoreFactory) {

--- a/testing.go
+++ b/testing.go
@@ -30,8 +30,6 @@ type MockStore struct {
 
 	Files           map[string][]byte
 	shouldOverwrite bool
-
-	meter Meter
 }
 
 func NewMockStore(writeFunc func(base string, f io.Reader) (err error)) *MockStore {
@@ -56,7 +54,6 @@ func (s *MockStore) SubStore(subFolder string) (Store, error) {
 
 	return &MockStore{
 		Files:             newFiles,
-		meter:             s.meter,
 		shouldOverwrite:   s.shouldOverwrite,
 		OpenObjectFunc:    s.OpenObjectFunc,
 		WriteObjectFunc:   s.WriteObjectFunc,
@@ -272,8 +269,4 @@ func (s *MockStore) PushLocalFile(ctx context.Context, localFile string, toBaseN
 
 func (s *MockStore) Overwrite() bool {
 	return s.shouldOverwrite
-}
-
-func (s *MockStore) SetMeter(meter Meter) {
-	s.meter = meter
 }


### PR DESCRIPTION
dstore is now agnostic to metering logic. 

callbacks are added to specific locations to allow user to instrument compressed/uncompressed reads and writes. 