### PR TITLE
S3 store: drain reader in WriteObject when skipping existing object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [MAINTAINERS.md](./MAINTAINERS.md) for instructions to keep up to date.
 
+## Unreleased
+
+### Fixed
+
+* S3 store: `WriteObject` now drains the input reader when skipping a write because the destination already exists and `overwrite` is disabled. Previously the reader was left untouched, which would deadlock pipe-based producers (e.g. a goroutine writing to an `io.Pipe`) and leak both the goroutine and any memory it had captured.
+
 ## v0.2.3
 
 ### Fixed

--- a/s3store.go
+++ b/s3store.go
@@ -320,7 +320,11 @@ func (s *S3Store) WriteObject(ctx context.Context, base string, f io.Reader, met
 	}
 
 	if !s.overwrite && exists {
-		// We silently ignore when we ask not to overwrite
+		// We silently ignore when we ask not to overwrite, but we still must
+		// consume the reader so that pipe-based producers (e.g. an io.Pipe fed
+		// by a goroutine) don't block forever waiting for a consumer that
+		// will never come.
+		_, _ = io.Copy(io.Discard, f)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

`S3Store.WriteObject` short-circuits with `return nil` when the destination already exists and `overwrite` is disabled — but it does so without ever reading from the input reader. Callers that feed the reader from a goroutine via `io.Pipe` end up blocking forever on their next `pipeWriter.Write`, leaking the goroutine and anything it had captured (e.g. the buffered records they were about to upload).

This was exposed by `firehose-core`'s `tools download-from-firehose`, where each pre-existing bundle in the destination bucket leaked one goroutine plus a captured slice of ~100 block payloads.

Drain the reader to `io.Discard` before returning, so producers complete cleanly. Other stores in this package don't have this problem:

- Local FS / Azure / memory: the writer always reads the reader through to EOF.
- GCS: the "doesn't already exist" check is a server-side `If(Conditions{DoesNotExist: true})` precondition; the upload still consumes the reader.

Only S3 used a client-side `FileExists` short-circuit that never touched `f`.

## Test plan

- [ ] `go build ./... && go vet ./...` (passes locally)
- [ ] Manual repro: run `firehose-core tools download-from-firehose` against an S3 destination that already contains the requested bundles; confirm the process no longer accumulates goroutines / heap as it iterates over existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)